### PR TITLE
Fix #1 - Fixing editing of existing blueprint

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,5 +1,7 @@
 node_modules
 yarn-error.log
 blueprints/
-sample_project
+sample_project_js
+sample_project_dart
 build
+.vscode

--- a/cli/src/commands/save-blueprint.command.ts
+++ b/cli/src/commands/save-blueprint.command.ts
@@ -9,23 +9,45 @@ import {
 } from "@gus_hill/scaffolding";
 import { basename } from "path";
 
-export class CreateBlueprintCommand {
+export class SaveBlueprintCommand {
   constructor(private fileReader: FileReader, private blueprintService: BlueprintService) {}
 
-  execute = async (blueprintName: string, { targetDirectory }: CreateBlueprintOptions) => {
+  execute = async (
+    blueprintName: string,
+    { targetDirectory, override }: CreateBlueprintOptions
+  ) => {
     targetDirectory = targetDirectory || process.cwd();
     const directoryExists = await this.fileReader.exists(targetDirectory);
     if (!directoryExists) {
       console.log(`The directory '${targetDirectory}' does not exist`);
       return;
     }
+    const blueprintExists = await this.blueprintService.blueprintExists(blueprintName);
+    if (blueprintExists) {
+      if (!override) {
+        console.error(
+          `Blueprint '${blueprintName}' already exists. Use the option '--override' to override an already existing blueprint.`
+        );
+        return;
+      } else {
+        console.log(`Blueprint '${blueprintName}' already exists, overriding it...`);
+      }
+    }
     const directoryItems = await this.readDirectoryBlueprint(targetDirectory);
-    await this.saveBlueprint(blueprintName, {
-      items: [
-        new DirectoryBlueprint(basename(targetDirectory), directoryItems.map(createBlueprint)),
-      ],
-    });
+    await this.saveBlueprint(
+      blueprintName,
+      {
+        items: [
+          new DirectoryBlueprint(basename(targetDirectory), directoryItems.map(createBlueprint)),
+        ],
+      },
+      { override }
+    ).catch(this.handleSaveError);
   };
+
+  private handleSaveError(error: Error): void {
+    console.error(`An error occurred while saving the blueprint: ${error.message}.`);
+  }
 
   private async readDirectoryBlueprint(targetDirectory: string): Promise<FSItem[]> {
     console.log(`Reading files of directory ${targetDirectory}...`);
@@ -49,13 +71,18 @@ export class CreateBlueprintCommand {
     return total;
   }
 
-  private async saveBlueprint(blueprintName: string, blueprint: ProjectBlueprint): Promise<void> {
+  private async saveBlueprint(
+    blueprintName: string,
+    blueprint: ProjectBlueprint,
+    { override }: { override?: boolean }
+  ): Promise<void> {
     console.log(`Saving blueprint ${blueprintName}...`);
-    await this.blueprintService.saveBlueprint(blueprintName, blueprint);
+    await this.blueprintService.saveBlueprint(blueprintName, blueprint, { override });
     console.log("Blueprint saved!");
   }
 }
 
 type CreateBlueprintOptions = {
   targetDirectory?: string;
+  override?: boolean;
 };

--- a/cli/src/di.ts
+++ b/cli/src/di.ts
@@ -11,7 +11,7 @@ import {
 import { MinimalDIContainer } from "minimal-di";
 import { normalize } from "path";
 import { BuildCommand } from "./commands/build.command";
-import { CreateBlueprintCommand } from "./commands/create-blueprint.command";
+import { SaveBlueprintCommand } from "./commands/save-blueprint.command";
 import { DeleteBlueprintCommand } from "./commands/delete-blueprint.command";
 import { ListBlueprintsCommand } from "./commands/list-blueprints.command";
 
@@ -33,8 +33,8 @@ diContainer.register(
   () => new ListBlueprintsCommand(diContainer.get(BlueprintService))
 );
 diContainer.register(
-  CreateBlueprintCommand,
-  () => new CreateBlueprintCommand(diContainer.get(FileReader), diContainer.get(BlueprintService))
+  SaveBlueprintCommand,
+  () => new SaveBlueprintCommand(diContainer.get(FileReader), diContainer.get(BlueprintService))
 );
 diContainer.register(
   DeleteBlueprintCommand,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import { BuildCommand } from "./commands/build.command";
-import { CreateBlueprintCommand } from "./commands/create-blueprint.command";
+import { SaveBlueprintCommand } from "./commands/save-blueprint.command";
 import { DeleteBlueprintCommand } from "./commands/delete-blueprint.command";
 import { ListBlueprintsCommand } from "./commands/list-blueprints.command";
 import { diContainer } from "./di";
@@ -10,9 +10,13 @@ const command = new Command("scaffold");
 command.command("build <blueprintName>").action(diContainer.get(BuildCommand).execute);
 
 command
-  .command("createBlueprint <blueprintName>")
-  .option("-t, --targetDirectory <targetDirectory>", "Target directory to create a blueprint for")
-  .action(diContainer.get(CreateBlueprintCommand).execute);
+  .command("saveBlueprint <blueprintName>")
+  .option("-t, --targetDirectory <targetDirectory>", "Target directory to create a save for")
+  .option(
+    "-o, --override",
+    "Flag indicating that if the blueprint already exists, it should be overwritten"
+  )
+  .action(diContainer.get(SaveBlueprintCommand).execute);
 
 command.command("listBlueprints").action(diContainer.get(ListBlueprintsCommand).execute);
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -23,6 +23,7 @@
     "start": "ts-node src/index.ts",
     "cli": "ts-node src/cli/cli.ts",
     "e2e": "ts-node node_modules/jasmine/bin/jasmine --config=tests/jasmine.e2e.json",
+    "e2e:watch": "nodemon --watch src --watch tests/e2e --exec \"npm run e2e\" -e ts",
     "test": "ts-node node_modules/jasmine/bin/jasmine --config=tests/jasmine.specs.json",
     "test:watch": "nodemon --watch src --watch tests/specs --exec \"npm run test\" -e ts",
     "coverage": "nyc -r text -e .ts --include src -x \"tests/**/*.spec.ts\" -x \"src/di.ts\" npm run test",

--- a/lib/src/types/error.ts
+++ b/lib/src/types/error.ts
@@ -15,3 +15,9 @@ export class InexistingBlueprintError extends Error {
     super(`The blueprint '${blueprintName}' does not exist`);
   }
 }
+
+export class BlueprintAlreadyExistsError extends Error {
+  constructor(blueprintName: string) {
+    super(`Blueprint '${blueprintName}' already exists`);
+  }
+}

--- a/lib/tests/specs/services/blueprint-service.spec.ts
+++ b/lib/tests/specs/services/blueprint-service.spec.ts
@@ -95,6 +95,34 @@ describe("BlueprintService", () => {
         ])
       );
     });
+
+    it("should throw error if the blueprint already exists", async () => {
+      fileReader.exists.and.returnValue(Promise.resolve(true));
+
+      const savePromise = blueprintService.saveBlueprint("test-blueprint", {
+        items: [new FileBlueprint("index.js", "console.log('Hello World!');")],
+      });
+
+      await expectAsync(savePromise).toBeRejected("Blueprint 'test-blueprint' already exists");
+      expect(fileReader.exists).toHaveBeenCalledOnceWith(join(rootDirectoryPath, "test-blueprint"));
+    });
+
+    it("should not throw error if the blueprint already exists and the override option is true", async () => {
+      fileReader.exists.and.returnValue(Promise.resolve(true));
+
+      const savePromise = blueprintService.saveBlueprint(
+        "test-blueprint",
+        {
+          items: [new FileBlueprint("index.js", "console.log('Hello World!');")],
+        },
+        {
+          override: true,
+        }
+      );
+
+      await expectAsync(savePromise).toBeResolved();
+      expect(fileReader.exists).toHaveBeenCalledOnceWith(join(rootDirectoryPath, "test-blueprint"));
+    });
   });
 
   describe("#blueprintExists", () => {


### PR DESCRIPTION
The BlueprintService#saveBlueprint method was modified to verify it the blueprint being saved already exists, and a `override` option was added, to delete the existing blueprint and save the new one.